### PR TITLE
Add ability to provide custom configuration

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,6 @@
-class ss_osquery::config inherits ::ss_osquery {
+class ss_osquery::config (
+    $config_object = {},
+) inherits ::ss_osquery {
 
     file { '/etc/osquery/osquery.conf':
         ensure  => 'file',

--- a/templates/osquery.conf.erb
+++ b/templates/osquery.conf.erb
@@ -1,3 +1,7 @@
+<%- if @config_object -%>
+<% require 'json' %>
+<%= JSON.pretty_generate(JSON.parse(@config_object.to_json)) %>
+<%- else -%>
 {
 	"options": {
 		"config_plugin": "filesystem",
@@ -91,3 +95,4 @@
 		}
 	}
 }
+<% end %>


### PR DESCRIPTION
Provide entire configuration as object eg
$config_object = {
    "options" => {
        "config_plugin" => "filesystem",
        "logger_plugin" => "syslog",
        "logger_path" => "/var/log/osquery",
        "worker_threads" => "<%= @processorcount %>",
        "enable_monitor" => "true",
        "verbose" => "false",
        "utc"=> "true",
    },
}