### PR TITLE
Convert plugin options to flags

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,13 +8,21 @@ class ss_osquery::config inherits ::ss_osquery {
         content => template('ss_osquery/osquery.conf.erb'),
         require => Package['osquery'],
     }
+    -> file { '/etc/osquery/osquery.flags':
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('ss_osquery/osquery.flags.erb'),
+        require => Package['osquery'],
+    }
     -> service { 'osqueryd':
         ensure     => true,
         enable     => true,
         hasstatus  => true,
         hasrestart => true,
         require    => Package['osquery'],
-        subscribe  => File['/etc/osquery/osquery.conf'],
+        subscribe  => [File['/etc/osquery/osquery.conf'], File['/etc/osquery/osquery.flags']],
     }
 
     file { '/etc/rsyslog.d/osquery.conf':

--- a/templates/osquery.conf.erb
+++ b/templates/osquery.conf.erb
@@ -4,11 +4,8 @@
 <%- else -%>
 {
 	"options": {
-		"config_plugin": "filesystem",
-		"logger_plugin": "syslog",
 		"logger_path": "/var/log/osquery",
 		"worker_threads": "<%= @processorcount %>",
-		"enable_monitor": "true",
 		"verbose": "false",
 		"utc": "true"
 	},

--- a/templates/osquery.flags.erb
+++ b/templates/osquery.flags.erb
@@ -1,0 +1,2 @@
+--config_plugin filesystem
+--logger_plugin syslog

--- a/templates/osquery.flags.erb
+++ b/templates/osquery.flags.erb
@@ -1,2 +1,2 @@
---config_plugin filesystem
---logger_plugin syslog
+--config_plugin=filesystem
+--logger_plugin=syslog


### PR DESCRIPTION
Osquery 5.4 now requires certain options to be passed as "flags" to osquery daemon.
https://osquery.readthedocs.io/en/stable/deployment/configuration/#options

>There are LOTs of CLI flags that CANNOT be set with the options key. These flags determine the start and initialization of osquery and configuration loading usually depends on these CLI-only flags. Refer to the --help list to determine the appropriateness of options.

These changes fix the following errors on Ubuntu 22.04 (Jammy)
```
W0812 14:55:46.141168  6776 options.cpp:106] The CLI only flag --config_plugin set via config file will be ignored, please use a flagfile or pass it to the process at startup
W0812 14:55:46.141561  6776 options.cpp:106] The CLI only flag --logger_plugin set via config file will be ignored, please use a flagfile or pass it to the process at startup
W0812 14:55:46.141685  6776 options.cpp:101] Cannot set unknown or invalid flag: enable_monitor
```

Without these changes, osquery does not log directly to Syslog and default to filesystem `/var/log/osquery`. Rsyslog is setup to monitor this folder, however does not have permission to read osquery log files, resulting in Permission Denied errors in Syslog.
```
2022-08-12T12:27:24.360751+12:00 ip-10-4-220-246 rsyslogd: imfile: error accessing file '/var/log/osquery/osqueryd.results.log': Permission denied [v8.2112.0]
```